### PR TITLE
Prototype lung seg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tclap"]
+	path = tclap
+	url = https://github.com/eile/tclap.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ INCLUDE_DIRECTORIES(
   # $ENV{HOME}/itk/itkWindowImageFilter/
   # $ENV{HOME}/itk/itkLabelSetErodeDilate_IJ_886/
   # filter/internal/
+  ${CMAKE_CURRENT_SOURCE_DIR}/tclap/include/
   )
 
 SET(Libraries
@@ -726,6 +727,11 @@ TARGET_LINK_LIBRARIES(${CurrentExe}  ${Libraries})
 INSTALL(TARGETS  ${CurrentExe}  RUNTIME  DESTINATION  bin)
 
 SET(CurrentExe "label_measures")
+ADD_EXECUTABLE(${CurrentExe}  ${CurrentExe})
+TARGET_LINK_LIBRARIES(${CurrentExe}  ${Libraries})
+INSTALL(TARGETS  ${CurrentExe}  RUNTIME  DESTINATION  bin)
+
+SET(CurrentExe "segmentLung")
 ADD_EXECUTABLE(${CurrentExe}  ${CurrentExe})
 TARGET_LINK_LIBRARIES(${CurrentExe}  ${Libraries})
 INSTALL(TARGETS  ${CurrentExe}  RUNTIME  DESTINATION  bin)

--- a/segmentLung.cxx
+++ b/segmentLung.cxx
@@ -1,20 +1,38 @@
 #include "itkFilterWatcher.h"
 #include <itkImageFileReader.h>
 #include <itkShiftScaleImageFilter.h>
-#include <itkMorphologicalWatershedImageFilter.h>
+#include <itkMorphologicalWatershedFromMarkersImageFilter.h>
 #include <itkImageFileWriter.h>
-#include <itkAreaClosingImageFilter.h>
+#include "itkFlatStructuringElement.h"
+#include "itkGrayscaleErodeImageFilter.h"
+#include <itkBinaryImageToShapeLabelMapFilter.h>
+#include <itkShapeOpeningLabelMapFilter.h>
+#include <itkOtsuThresholdImageFilter.h>
+#include <itkParabolicErodeImageFilter.h>
+#include <itkLabelMapToLabelImageFilter.h>
+#include <itkStatisticsImageFilter.h>
+#include <itkShiftScaleImageFilter.h>
+#include <itkMaximumImageFilter.h>
+#include <itkLabelStatisticsImageFilter.h>
+#include <itkMaskImageFilter.h>
+#include <itkSubtractImageFilter.h>
+#include <itkSmoothingRecursiveGaussianImageFilter.h>
+#include <itkChangeLabelImageFilter.h>
 
 #include "tclap/CmdLine.h"
 
 bool WriteDebug = false;
+bool Compression = false;
+std::string DebugDir("./");
 
 template <class TImage>
 void writeIm(typename TImage::Pointer Im, std::string filename)
 {
   typedef typename itk::ImageFileWriter<TImage> WriterType;
   typename WriterType::Pointer writer = WriterType::New();
+  FilterWatcher watcherO(writer);
   writer->SetInput(Im);
+  writer->SetUseCompression(Compression);
   writer->SetFileName(filename.c_str());
   writer->Update();
 }
@@ -25,7 +43,7 @@ void writeImDbg(typename ImType::Pointer Im, std::string filename)
 {
   if (WriteDebug)
     {
-    writeIm<ImType>(Im, filename);
+    writeIm<ImType>(Im, DebugDir + filename);
     }
 }
 
@@ -34,7 +52,8 @@ typedef class CmdLineType
 {
 public:
   std::string InputImFile, OutputImFile;
-  int DarkVol;
+  int DarkVol, markererode, markervolume, MorphGradRad;
+  float SmoothGradSigma;
   bool Compression;
 } CmdLineType;
 
@@ -55,11 +74,30 @@ void ParseCmdLine(int argc, char* argv[],
     ValueArg<std::string> outArg("o","output","output image", true,"","string");
     cmd.add( outArg );
 
-    ValueArg<int> darkArg("","darkvol","Volume used for attribute closing (voxels)",true, 3000, "integer");
-    cmd.add( darkArg);
+    // ValueArg<int> darkArg("","darkvol","Volume used for attribute closing (voxels)",true, 3000, "integer");
+    // cmd.add( darkArg);
+
+    ValueArg<int> markererodeArg("","markererode","Radius of erosion of thresholded image used to produce markers (voxels)",true, 30, "integer");
+    cmd.add( markererodeArg);
+
+    ValueArg<int> markervolArg("","markervol","Minimum volume of a bright marker",false, 100000, "integer");
+    cmd.add( markervolArg);
+
+    ValueArg<int> morphgradArg("","morphgradrad","Radius of SE for morphologicad gradient",false, 1, "integer");
+    cmd.add( morphgradArg );
+
+    ValueArg<float> gradsmoothArg("","gradsigma","Smoothing kernel (voxels)",false, 1, "float");
+    cmd.add( gradsmoothArg);
 
     SwitchArg compArg("c", "compress", "write compressed images", false);
     cmd.add( compArg );
+
+    SwitchArg dbgArg("d", "debug", "write debug images", false);
+    cmd.add( dbgArg );
+
+    ValueArg<std::string> dfArg("","debugfolder","location for debug images", false,"/tmp/","string");
+    cmd.add( dfArg );
+
 
    // Parse the args.
     cmd.parse( argc, argv );
@@ -67,9 +105,15 @@ void ParseCmdLine(int argc, char* argv[],
     // Get the value parsed by each arg.
     CmdLineObj.InputImFile = inArg.getValue();
     CmdLineObj.OutputImFile = outArg.getValue();
-    CmdLineObj.DarkVol = darkArg.getValue();
+    //CmdLineObj.DarkVol = darkArg.getValue();
     CmdLineObj.Compression = compArg.getValue();
-
+    CmdLineObj.markererode = markererodeArg.getValue();
+    CmdLineObj.markervolume = markervolArg.getValue();
+    CmdLineObj.MorphGradRad = morphgradArg.getValue();
+    CmdLineObj.SmoothGradSigma = gradsmoothArg.getValue();
+    Compression = CmdLineObj.Compression;
+    WriteDebug = dbgArg.getValue();
+    DebugDir = dfArg.getValue();
     }
   catch (ArgException &e)  // catch any exceptions
     {
@@ -77,6 +121,192 @@ void ParseCmdLine(int argc, char* argv[],
     }
 }
 
+template <class InImType, class OutputImType> 
+typename OutputImType::Pointer findBrightMarkers(typename InImType::Pointer input, 
+						 int erad,
+						 int volumeopening,
+						 int &MaxLabel)
+{
+  // basic marker finding. Threshold, erode binary and keep larger
+  // blobs
+  typedef typename itk::Image<unsigned char, InImType::ImageDimension > BinaryType;
+  typedef typename itk::OtsuThresholdImageFilter<InImType, BinaryType> OtsuType;
+  typename OtsuType::Pointer Otsu = OtsuType::New();
+  Otsu->SetInput(input);
+  Otsu->SetInsideValue(0);
+  Otsu->SetOutsideValue(1);
+
+  typedef typename itk::ParabolicErodeImageFilter<BinaryType, BinaryType> EType;
+  typename EType::Pointer eroder = EType::New();
+  eroder->SetInput(Otsu->GetOutput());
+  eroder->SetUseImageSpacing(false);
+  eroder->SetScale(erad);
+
+  typedef typename itk::BinaryImageToShapeLabelMapFilter<BinaryType> LabellerType;
+  typename LabellerType::Pointer labeller = LabellerType::New();
+  labeller->SetInput(eroder->GetOutput());
+  labeller->SetInputForegroundValue(1);
+  typedef typename itk::ShapeOpeningLabelMapFilter<typename LabellerType::OutputImageType> ShapeFilterType;
+  typename ShapeFilterType::Pointer shapefilter = ShapeFilterType::New();
+  shapefilter->SetLambda(volumeopening);
+  shapefilter->SetAttribute("NumberOfPixels");
+  shapefilter->SetInput(labeller->GetOutput());
+  
+  typedef typename itk::LabelMapToLabelImageFilter<typename LabellerType::OutputImageType, OutputImType> ConvType;
+
+  typename ConvType::Pointer tolabIm = ConvType::New();
+  tolabIm->SetInput(shapefilter->GetOutput());
+  
+  typename OutputImType::Pointer result = tolabIm->GetOutput();
+  result->Update();
+  result->DisconnectPipeline();
+  MaxLabel = labeller->GetOutput()->GetNumberOfLabelObjects();
+  return(result);
+}
+
+template <class InImType, class OutputImType> 
+typename OutputImType::Pointer findDarkMarkersWS(typename InImType::Pointer input,
+						 typename OutputImType::Pointer markers,
+						 int BorderLabel)
+{
+  // Tesselate the bright regions by doing a watershed on the inverted
+  // input.
+  // Invert by subtracting input from the max, so no funny business
+  // with unsigned types.
+
+  typedef typename itk::StatisticsImageFilter<InImType> StatsType;
+  typename StatsType::Pointer stats = StatsType::New();
+  stats->SetInput(input);
+  stats->Update();
+
+  typedef typename itk::ShiftScaleImageFilter<InImType, InImType> ShiftType;
+  typename ShiftType::Pointer shifter = ShiftType::New();
+  shifter->SetInput(input);
+  shifter->SetShift(- stats->GetMaximum() );
+  shifter->SetScale(-1);
+
+  typedef typename itk::MorphologicalWatershedFromMarkersImageFilter<InImType, OutputImType> WSType;
+  typename WSType::Pointer ws = WSType::New();
+  FilterWatcher watcherws1(ws);
+  ws->SetInput(shifter->GetOutput());
+  ws->SetMarkerImage(markers);
+  ws->SetMarkWatershedLine(true);
+
+  typedef typename itk::BinaryThresholdImageFilter<OutputImType, OutputImType> SelectType;
+  typename SelectType::Pointer select = SelectType::New();
+  select->SetInput(ws->GetOutput());
+  select->SetLowerThreshold(0);
+  select->SetUpperThreshold(0);
+  select->SetInsideValue(BorderLabel);
+  select->SetOutsideValue(0);
+  // Sometimes a foreground marker will be incorrectly broken in
+  // two, leading to an undesired boundary splitting them after the
+  // first stage watershed. This will make it difficult to join
+  // regions in the interactive phase. Can try removing pixels from
+  // the dark markers, if they are too bright. The importance of this
+  // step will depend on a combination of the erosion size and topology.
+  // Take mean and SD of markers, discard borders that are bright by
+  // this metric.
+
+  // compute label stats of the marker image - should be a binary, but
+  // I can't be bothered thresholding again. We'll just use the stats
+  // of the biggest marker. TODO combine mean, count and SD - look up
+  // the formula
+  typedef typename itk::LabelStatisticsImageFilter<InImType, OutputImType> LabStatsType;
+
+  typename LabStatsType::Pointer markstats = LabStatsType::New();
+  markstats->SetInput(input);
+  markstats->SetLabelInput(markers);
+  markstats->Update();
+  
+  typedef typename LabStatsType::ValidLabelValuesContainerType ValidLabelValuesType;
+  int msize = 0;
+  typename LabStatsType::RealType MMean(0), MSigma(0);
+
+  for (typename ValidLabelValuesType::const_iterator vIt=markstats->GetValidLabelValues().begin();
+      vIt != markstats->GetValidLabelValues().end();
+      ++vIt)
+    {
+    if ( markstats->HasLabel(*vIt) )
+      {
+      typename OutputImType::PixelType labelValue = *vIt;
+      if ( markstats->GetCount(labelValue) > msize) 
+	{
+	msize = markstats->GetCount(labelValue);
+	MMean = markstats->GetMean(labelValue);
+	MSigma = markstats->GetSigma(labelValue);
+	}
+      }
+    }
+
+  std::cout << "Stats " << msize << " " << MMean << " " << MSigma << std::endl;
+
+  // create a mask to remove bright border pixels
+  typedef typename itk::Image<unsigned char, InImType::ImageDimension > MaskImType;
+  typedef typename itk::BinaryThresholdImageFilter<InImType, MaskImType> ThreshType;
+  typename ThreshType::Pointer thresh = ThreshType::New();
+  thresh->SetInput(input);
+  thresh->SetUpperThreshold(MMean - MSigma);
+  thresh->SetInsideValue(1);
+  thresh->SetOutsideValue(0);
+
+  typedef typename itk::MaskImageFilter<OutputImType, MaskImType, OutputImType> MaskerType;
+  typename MaskerType::Pointer masker = MaskerType::New();
+  masker->SetInput(select->GetOutput());
+  masker->SetInput2(thresh->GetOutput());
+
+  typename OutputImType::Pointer result = masker->GetOutput();
+  result->Update();
+  result->DisconnectPipeline();
+  return(result);
+}
+
+template <class InImType> 
+typename InImType::Pointer computeGrad(typename InImType::Pointer input,
+					   int radius,
+					   float smooth)
+{
+  // Compute a smoothed morphological gradient - original - erosion
+  // optionally smooth it. This gradient will put the peaks on the
+  // outside of a thin dark line, which I think is desirable for this
+  // application.
+  typedef typename itk::FlatStructuringElement< InImType::ImageDimension > SRType;
+  typename SRType::RadiusType rad;
+  rad.Fill(radius);
+  SRType kernel;
+
+  kernel = SRType::Box(rad);
+
+  typedef typename itk::GrayscaleErodeImageFilter<InImType, InImType, SRType> ErodeType;
+  typename ErodeType::Pointer erode = ErodeType::New();
+  erode->SetInput(input);
+  erode->SetKernel(kernel);
+
+  typedef typename itk::SubtractImageFilter<InImType, InImType, InImType> SubType;
+  typename SubType::Pointer sub = SubType::New();
+  sub->SetInput(input);
+  sub->SetInput2(erode->GetOutput());
+  typename InImType::Pointer result = sub->GetOutput();
+  typedef typename itk::SmoothingRecursiveGaussianImageFilter<InImType, InImType> SmoothType;
+  typename SmoothType::Pointer smoother = SmoothType::New();
+  
+  typename InImType::SpacingType sp = input->GetSpacing();
+
+  if (smooth > 0)
+    {
+    // Lazy - assume isotropic
+    float sigma = sp[0] * smooth;
+    smoother->SetInput(sub->GetOutput());
+    smoother->SetSigma(sigma);
+    result = smoother->GetOutput();
+    }
+
+  result->Update();
+  result->DisconnectPipeline();
+  return(result);
+}
+#define USE_FLOAT
+#define USE_UI32
 template<typename InputComponentType, typename InputPixelType, size_t Dimension>
 int DoIt(CmdLineType &CmdLineObj){
 #ifdef USE_FLOAT
@@ -102,7 +332,7 @@ int DoIt(CmdLineType &CmdLineObj){
     typename ReaderType::Pointer reader = ReaderType::New();
 
     reader->SetFileName(CmdLineObj.InputImFile);
-    reader->ReleaseDataFlagOn();
+    //reader->ReleaseDataFlagOn();
     FilterWatcher watcherI(reader);
     watcherI.QuietOn();
     watcherI.ReportTimeOn();
@@ -114,28 +344,46 @@ int DoIt(CmdLineType &CmdLineObj){
         return EXIT_FAILURE;
         }
 
-    // Try some preprocessing - attribute filter
-    typedef typename itk::AreaClosingImageFilter<InputImageType, InputImageType> ACType;
-    typename ACType::Pointer areaclose = ACType::New();
-    areaclose->SetInput(reader->GetOutput());
-    areaclose->SetLambda(CmdLineObj.DarkVol);
-    areaclose->UseImageSpacingOff();
 
-    typedef itk::ImageFileWriter<InputImageType>  WriterType;
-    typename WriterType::Pointer writer = WriterType::New();
+    std::cout << "Bright markers" << std::endl;
+    // Markers will be large areas
+    int ForegroundLabels = 0;
+    typename OutputImageType::Pointer brightmarkers =
+      findBrightMarkers<InputImageType, OutputImageType>(reader->GetOutput(), CmdLineObj.markererode, CmdLineObj.markervolume, ForegroundLabels);
 
+    std::cout << "Dark markers" << std::endl;
+    typename OutputImageType::Pointer darkmarkers = findDarkMarkersWS<InputImageType, OutputImageType>(reader->GetOutput(), brightmarkers, ForegroundLabels+1);
+
+
+    typedef typename itk::MaximumImageFilter<OutputImageType, OutputImageType, OutputImageType> MaxType;
+
+    typename MaxType::Pointer comb = MaxType::New();
+    comb->SetInput(brightmarkers);
+    comb->SetInput2(darkmarkers);
     
-    FilterWatcher watcherO(writer);
-    writer->SetFileName(CmdLineObj.OutputImFile);
-    writer->SetInput(areaclose->GetOutput());
-    writer->SetUseCompression(CmdLineObj.Compression);
-    try{
-        writer->Update();
-        }
-    catch(itk::ExceptionObject &ex){
-        std::cerr << ex << std::endl;
-        return EXIT_FAILURE;
-        }
+        
+    std::cout << "Gradient" << std::endl;
+    typename InputImageType::Pointer grad = computeGrad<InputImageType>(reader->GetOutput(), CmdLineObj.MorphGradRad, CmdLineObj.SmoothGradSigma);
+
+    writeImDbg<OutputImageType>(comb->GetOutput(), "markers.mha");
+
+    std::cout << "Watershed" << std::endl;
+
+    typedef typename itk::MorphologicalWatershedFromMarkersImageFilter<InputImageType, OutputImageType> WSType;
+    typename WSType::Pointer ws = WSType::New();
+    FilterWatcher watcherWS2(ws);
+    ws->SetInput(grad);
+    ws->SetMarkerImage(comb->GetOutput());
+    ws->SetMarkWatershedLine(false);
+
+
+    typedef typename itk::ChangeLabelImageFilter<OutputImageType, OutputImageType> ChangeType;
+    typename ChangeType::Pointer changer = ChangeType::New();
+    changer->SetInput(ws->GetOutput());
+    changer->SetChange(ForegroundLabels+1, 0);
+
+    writeIm<OutputImageType>(changer->GetOutput(), CmdLineObj.OutputImFile);
+
 
     return EXIT_SUCCESS;
  
@@ -276,7 +524,7 @@ int main(int argc, char *argv[]){
 
 
     try {
-        GetImageType(argv[1], pixelType, componentType, dimensionType);
+    GetImageType(CmdLineObj.InputImFile, pixelType, componentType, dimensionType);
         }//try
     catch( itk::ExceptionObject &excep){
         std::cerr << argv[0] << ": exception caught !" << std::endl;

--- a/segmentLung.cxx
+++ b/segmentLung.cxx
@@ -3,8 +3,8 @@
 #include <itkShiftScaleImageFilter.h>
 #include <itkMorphologicalWatershedFromMarkersImageFilter.h>
 #include <itkImageFileWriter.h>
-#include "itkFlatStructuringElement.h"
-#include "itkGrayscaleErodeImageFilter.h"
+#include <itkFlatStructuringElement.h>
+#include <itkGrayscaleErodeImageFilter.h>
 #include <itkBinaryImageToShapeLabelMapFilter.h>
 #include <itkShapeOpeningLabelMapFilter.h>
 #include <itkOtsuThresholdImageFilter.h>
@@ -26,285 +26,273 @@ bool Compression = false;
 std::string DebugDir("./");
 
 template <class TImage>
-void writeIm(typename TImage::Pointer Im, std::string filename)
-{
-  typedef typename itk::ImageFileWriter<TImage> WriterType;
-  typename WriterType::Pointer writer = WriterType::New();
-  FilterWatcher watcherO(writer);
-  writer->SetInput(Im);
-  writer->SetUseCompression(Compression);
-  writer->SetFileName(filename.c_str());
-  writer->Update();
-}
+void writeIm(typename TImage::Pointer Im, std::string filename){
+    typedef typename itk::ImageFileWriter<TImage> WriterType;
+    typename WriterType::Pointer writer = WriterType::New();
+    FilterWatcher watcherO(writer);
+    writer->SetInput(Im);
+    writer->SetUseCompression(Compression);
+    writer->SetFileName(filename.c_str());
+    writer->Update();
+    }
 
 
 template <class ImType>
-void writeImDbg(typename ImType::Pointer Im, std::string filename)
-{
-  if (WriteDebug)
-    {
-    writeIm<ImType>(Im, DebugDir + filename);
-    }
-}
-
-
-typedef class CmdLineType
-{
-public:
-  std::string InputImFile, OutputImFile;
-  int DarkVol, markererode, markervolume, MorphGradRad;
-  float SmoothGradSigma;
-  bool Compression;
-} CmdLineType;
-
-void ParseCmdLine(int argc, char* argv[],
-                  CmdLineType &CmdLineObj
-                  )
-{
-  using namespace TCLAP;
-  try
-    {
-    // Define the command line object.
-    CmdLine cmd("Lung segmentation prototype ", ' ', "0.9");
-
-
-    ValueArg<std::string> inArg("i","input","input image",true,"result","string");
-    cmd.add( inArg );
-
-    ValueArg<std::string> outArg("o","output","output image", true,"","string");
-    cmd.add( outArg );
-
-    // ValueArg<int> darkArg("","darkvol","Volume used for attribute closing (voxels)",true, 3000, "integer");
-    // cmd.add( darkArg);
-
-    ValueArg<int> markererodeArg("","markererode","Radius of erosion of thresholded image used to produce markers (voxels)",true, 30, "integer");
-    cmd.add( markererodeArg);
-
-    ValueArg<int> markervolArg("","markervol","Minimum volume of a bright marker",false, 100000, "integer");
-    cmd.add( markervolArg);
-
-    ValueArg<int> morphgradArg("","morphgradrad","Radius of SE for morphologicad gradient",false, 1, "integer");
-    cmd.add( morphgradArg );
-
-    ValueArg<float> gradsmoothArg("","gradsigma","Smoothing kernel (voxels)",false, 1, "float");
-    cmd.add( gradsmoothArg);
-
-    SwitchArg compArg("c", "compress", "write compressed images", false);
-    cmd.add( compArg );
-
-    SwitchArg dbgArg("d", "debug", "write debug images", false);
-    cmd.add( dbgArg );
-
-    ValueArg<std::string> dfArg("","debugfolder","location for debug images", false,"/tmp/","string");
-    cmd.add( dfArg );
-
-
-   // Parse the args.
-    cmd.parse( argc, argv );
-
-    // Get the value parsed by each arg.
-    CmdLineObj.InputImFile = inArg.getValue();
-    CmdLineObj.OutputImFile = outArg.getValue();
-    //CmdLineObj.DarkVol = darkArg.getValue();
-    CmdLineObj.Compression = compArg.getValue();
-    CmdLineObj.markererode = markererodeArg.getValue();
-    CmdLineObj.markervolume = markervolArg.getValue();
-    CmdLineObj.MorphGradRad = morphgradArg.getValue();
-    CmdLineObj.SmoothGradSigma = gradsmoothArg.getValue();
-    Compression = CmdLineObj.Compression;
-    WriteDebug = dbgArg.getValue();
-    DebugDir = dfArg.getValue();
-    }
-  catch (ArgException &e)  // catch any exceptions
-    {
-    std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl;
-    }
-}
-
-template <class InImType, class OutputImType> 
-typename OutputImType::Pointer findBrightMarkers(typename InImType::Pointer input, 
-						 int erad,
-						 int volumeopening,
-						 int &MaxLabel)
-{
-  // basic marker finding. Threshold, erode binary and keep larger
-  // blobs
-  typedef typename itk::Image<unsigned char, InImType::ImageDimension > BinaryType;
-  typedef typename itk::OtsuThresholdImageFilter<InImType, BinaryType> OtsuType;
-  typename OtsuType::Pointer Otsu = OtsuType::New();
-  Otsu->SetInput(input);
-  Otsu->SetInsideValue(0);
-  Otsu->SetOutsideValue(1);
-
-  typedef typename itk::ParabolicErodeImageFilter<BinaryType, BinaryType> EType;
-  typename EType::Pointer eroder = EType::New();
-  eroder->SetInput(Otsu->GetOutput());
-  eroder->SetUseImageSpacing(false);
-  eroder->SetScale(erad);
-
-  typedef typename itk::BinaryImageToShapeLabelMapFilter<BinaryType> LabellerType;
-  typename LabellerType::Pointer labeller = LabellerType::New();
-  labeller->SetInput(eroder->GetOutput());
-  labeller->SetInputForegroundValue(1);
-  typedef typename itk::ShapeOpeningLabelMapFilter<typename LabellerType::OutputImageType> ShapeFilterType;
-  typename ShapeFilterType::Pointer shapefilter = ShapeFilterType::New();
-  shapefilter->SetLambda(volumeopening);
-  shapefilter->SetAttribute("NumberOfPixels");
-  shapefilter->SetInput(labeller->GetOutput());
-  
-  typedef typename itk::LabelMapToLabelImageFilter<typename LabellerType::OutputImageType, OutputImType> ConvType;
-
-  typename ConvType::Pointer tolabIm = ConvType::New();
-  tolabIm->SetInput(shapefilter->GetOutput());
-  
-  typename OutputImType::Pointer result = tolabIm->GetOutput();
-  result->Update();
-  result->DisconnectPipeline();
-  MaxLabel = labeller->GetOutput()->GetNumberOfLabelObjects();
-  return(result);
-}
-
-template <class InImType, class OutputImType> 
-typename OutputImType::Pointer findDarkMarkersWS(typename InImType::Pointer input,
-						 typename OutputImType::Pointer markers,
-						 int BorderLabel)
-{
-  // Tesselate the bright regions by doing a watershed on the inverted
-  // input.
-  // Invert by subtracting input from the max, so no funny business
-  // with unsigned types.
-
-  typedef typename itk::StatisticsImageFilter<InImType> StatsType;
-  typename StatsType::Pointer stats = StatsType::New();
-  stats->SetInput(input);
-  stats->Update();
-
-  typedef typename itk::ShiftScaleImageFilter<InImType, InImType> ShiftType;
-  typename ShiftType::Pointer shifter = ShiftType::New();
-  shifter->SetInput(input);
-  shifter->SetShift(- stats->GetMaximum() );
-  shifter->SetScale(-1);
-
-  typedef typename itk::MorphologicalWatershedFromMarkersImageFilter<InImType, OutputImType> WSType;
-  typename WSType::Pointer ws = WSType::New();
-  FilterWatcher watcherws1(ws);
-  ws->SetInput(shifter->GetOutput());
-  ws->SetMarkerImage(markers);
-  ws->SetMarkWatershedLine(true);
-
-  typedef typename itk::BinaryThresholdImageFilter<OutputImType, OutputImType> SelectType;
-  typename SelectType::Pointer select = SelectType::New();
-  select->SetInput(ws->GetOutput());
-  select->SetLowerThreshold(0);
-  select->SetUpperThreshold(0);
-  select->SetInsideValue(BorderLabel);
-  select->SetOutsideValue(0);
-  // Sometimes a foreground marker will be incorrectly broken in
-  // two, leading to an undesired boundary splitting them after the
-  // first stage watershed. This will make it difficult to join
-  // regions in the interactive phase. Can try removing pixels from
-  // the dark markers, if they are too bright. The importance of this
-  // step will depend on a combination of the erosion size and topology.
-  // Take mean and SD of markers, discard borders that are bright by
-  // this metric.
-
-  // compute label stats of the marker image - should be a binary, but
-  // I can't be bothered thresholding again. We'll just use the stats
-  // of the biggest marker. TODO combine mean, count and SD - look up
-  // the formula
-  typedef typename itk::LabelStatisticsImageFilter<InImType, OutputImType> LabStatsType;
-
-  typename LabStatsType::Pointer markstats = LabStatsType::New();
-  markstats->SetInput(input);
-  markstats->SetLabelInput(markers);
-  markstats->Update();
-  
-  typedef typename LabStatsType::ValidLabelValuesContainerType ValidLabelValuesType;
-  int msize = 0;
-  typename LabStatsType::RealType MMean(0), MSigma(0);
-
-  for (typename ValidLabelValuesType::const_iterator vIt=markstats->GetValidLabelValues().begin();
-      vIt != markstats->GetValidLabelValues().end();
-      ++vIt)
-    {
-    if ( markstats->HasLabel(*vIt) )
-      {
-      typename OutputImType::PixelType labelValue = *vIt;
-      if ( markstats->GetCount(labelValue) > msize) 
-	{
-	msize = markstats->GetCount(labelValue);
-	MMean = markstats->GetMean(labelValue);
-	MSigma = markstats->GetSigma(labelValue);
+void writeImDbg(typename ImType::Pointer Im, std::string filename){
+    if (WriteDebug){
+	writeIm<ImType>(Im, DebugDir + filename);
 	}
-      }
     }
 
-  std::cout << "Stats " << msize << " " << MMean << " " << MSigma << std::endl;
 
-  // create a mask to remove bright border pixels
-  typedef typename itk::Image<unsigned char, InImType::ImageDimension > MaskImType;
-  typedef typename itk::BinaryThresholdImageFilter<InImType, MaskImType> ThreshType;
-  typename ThreshType::Pointer thresh = ThreshType::New();
-  thresh->SetInput(input);
-  thresh->SetUpperThreshold(MMean - MSigma);
-  thresh->SetInsideValue(1);
-  thresh->SetOutsideValue(0);
+typedef class CmdLineType{
+public:
+    std::string InputImFile, OutputImFile;
+    int DarkVol, markererode, markervolume, MorphGradRad;
+    float SmoothGradSigma;
+    bool Compression;
+    } CmdLineType;
 
-  typedef typename itk::MaskImageFilter<OutputImType, MaskImType, OutputImType> MaskerType;
-  typename MaskerType::Pointer masker = MaskerType::New();
-  masker->SetInput(select->GetOutput());
-  masker->SetInput2(thresh->GetOutput());
+void ParseCmdLine(int argc, char* argv[], CmdLineType &CmdLineObj){
+    using namespace TCLAP;
+    try {
+	// Define the command line object.
+	CmdLine cmd("Lung segmentation prototype ", ' ', "0.9");
 
-  typename OutputImType::Pointer result = masker->GetOutput();
-  result->Update();
-  result->DisconnectPipeline();
-  return(result);
-}
+
+	ValueArg<std::string> inArg("i","input","input image",true,"result","string");
+	cmd.add( inArg );
+
+	ValueArg<std::string> outArg("o","output","output image", true,"","string");
+	cmd.add( outArg );
+
+	// ValueArg<int> darkArg("","darkvol","Volume used for attribute closing (voxels)",true, 3000, "integer");
+	// cmd.add( darkArg);
+
+	ValueArg<int> markererodeArg("","markererode","Radius of erosion of thresholded image used to produce markers (voxels)",true, 30, "integer");
+	cmd.add( markererodeArg);
+
+	ValueArg<int> markervolArg("","markervol","Minimum volume of a bright marker",false, 100000, "integer");
+	cmd.add( markervolArg);
+
+	ValueArg<int> morphgradArg("","morphgradrad","Radius of SE for morphologicad gradient",false, 1, "integer");
+	cmd.add( morphgradArg );
+
+	ValueArg<float> gradsmoothArg("","gradsigma","Smoothing kernel (voxels)",false, 1, "float");
+	cmd.add( gradsmoothArg);
+
+	SwitchArg compArg("c", "compress", "write compressed images", false);
+	cmd.add( compArg );
+
+	SwitchArg dbgArg("d", "debug", "write debug images", false);
+	cmd.add( dbgArg );
+
+	ValueArg<std::string> dfArg("","debugfolder","location for debug images", false,"/tmp/","string");
+	cmd.add( dfArg );
+
+
+	// Parse the args.
+	cmd.parse( argc, argv );
+
+	// Get the value parsed by each arg.
+	CmdLineObj.InputImFile = inArg.getValue();
+	CmdLineObj.OutputImFile = outArg.getValue();
+	//CmdLineObj.DarkVol = darkArg.getValue();
+	CmdLineObj.Compression = compArg.getValue();
+	CmdLineObj.markererode = markererodeArg.getValue();
+	CmdLineObj.markervolume = markervolArg.getValue();
+	CmdLineObj.MorphGradRad = morphgradArg.getValue();
+	CmdLineObj.SmoothGradSigma = gradsmoothArg.getValue();
+	Compression = CmdLineObj.Compression;
+	WriteDebug = dbgArg.getValue();
+	DebugDir = dfArg.getValue();
+	}
+    catch (ArgException &e)  // catch any exceptions
+	{
+	std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl;
+	}
+    }
+
+template <class InImType, class OutputImType> 
+typename OutputImType::Pointer findBrightMarkers(
+    typename InImType::Pointer input, 
+    int erad,
+    int volumeopening,
+    int &MaxLabel){
+    // basic marker finding. Threshold, erode binary and keep larger
+    // blobs
+    typedef typename itk::Image<unsigned char, InImType::ImageDimension > BinaryType;
+    typedef typename itk::OtsuThresholdImageFilter<InImType, BinaryType> OtsuType;
+    typename OtsuType::Pointer Otsu = OtsuType::New();
+    Otsu->SetInput(input);
+    Otsu->SetInsideValue(0);
+    Otsu->SetOutsideValue(1);
+
+    typedef typename itk::ParabolicErodeImageFilter<BinaryType, BinaryType> EType;
+    typename EType::Pointer eroder = EType::New();
+    eroder->SetInput(Otsu->GetOutput());
+    eroder->SetUseImageSpacing(false);
+    eroder->SetScale(erad);
+
+    typedef typename itk::BinaryImageToShapeLabelMapFilter<BinaryType> LabellerType;
+    typename LabellerType::Pointer labeller = LabellerType::New();
+    labeller->SetInput(eroder->GetOutput());
+    labeller->SetInputForegroundValue(1);
+    typedef typename itk::ShapeOpeningLabelMapFilter<typename LabellerType::OutputImageType> ShapeFilterType;
+    typename ShapeFilterType::Pointer shapefilter = ShapeFilterType::New();
+    shapefilter->SetLambda(volumeopening);
+    shapefilter->SetAttribute("NumberOfPixels");
+    shapefilter->SetInput(labeller->GetOutput());
+  
+    typedef typename itk::LabelMapToLabelImageFilter<typename LabellerType::OutputImageType, OutputImType> ConvType;
+
+    typename ConvType::Pointer tolabIm = ConvType::New();
+    tolabIm->SetInput(shapefilter->GetOutput());
+  
+    typename OutputImType::Pointer result = tolabIm->GetOutput();
+    result->Update();
+    result->DisconnectPipeline();
+    MaxLabel = labeller->GetOutput()->GetNumberOfLabelObjects();
+    return(result);
+    }
+
+template <class InImType, class OutputImType> 
+typename OutputImType::Pointer findDarkMarkersWS(
+    typename InImType::Pointer input,
+    typename OutputImType::Pointer markers,
+    int BorderLabel){
+    // Tesselate the bright regions by doing a watershed on the inverted
+    // input.
+    // Invert by subtracting input from the max, so no funny business
+    // with unsigned types.
+
+    typedef typename itk::StatisticsImageFilter<InImType> StatsType;
+    typename StatsType::Pointer stats = StatsType::New();
+    stats->SetInput(input);
+    stats->Update();
+
+    typedef typename itk::ShiftScaleImageFilter<InImType, InImType> ShiftType;
+    typename ShiftType::Pointer shifter = ShiftType::New();
+    shifter->SetInput(input);
+    shifter->SetShift(- stats->GetMaximum() );
+    shifter->SetScale(-1);
+
+    typedef typename itk::MorphologicalWatershedFromMarkersImageFilter<InImType, OutputImType> WSType;
+    typename WSType::Pointer ws = WSType::New();
+    FilterWatcher watcherws1(ws);
+    ws->SetInput(shifter->GetOutput());
+    ws->SetMarkerImage(markers);
+    ws->SetMarkWatershedLine(true);
+
+    typedef typename itk::BinaryThresholdImageFilter<OutputImType, OutputImType> SelectType;
+    typename SelectType::Pointer select = SelectType::New();
+    select->SetInput(ws->GetOutput());
+    select->SetLowerThreshold(0);
+    select->SetUpperThreshold(0);
+    select->SetInsideValue(BorderLabel);
+    select->SetOutsideValue(0);
+    // Sometimes a foreground marker will be incorrectly broken in
+    // two, leading to an undesired boundary splitting them after the
+    // first stage watershed. This will make it difficult to join
+    // regions in the interactive phase. Can try removing pixels from
+    // the dark markers, if they are too bright. The importance of this
+    // step will depend on a combination of the erosion size and topology.
+    // Take mean and SD of markers, discard borders that are bright by
+    // this metric.
+
+    // compute label stats of the marker image - should be a binary, but
+    // I can't be bothered thresholding again. We'll just use the stats
+    // of the biggest marker. TODO combine mean, count and SD - look up
+    // the formula
+    typedef typename itk::LabelStatisticsImageFilter<InImType, OutputImType> LabStatsType;
+
+    typename LabStatsType::Pointer markstats = LabStatsType::New();
+    markstats->SetInput(input);
+    markstats->SetLabelInput(markers);
+    markstats->Update();
+  
+    typedef typename LabStatsType::ValidLabelValuesContainerType ValidLabelValuesType;
+    int msize = 0;
+    typename LabStatsType::RealType MMean(0), MSigma(0);
+
+    for (typename ValidLabelValuesType::const_iterator vIt=markstats->GetValidLabelValues().begin();
+	 vIt != markstats->GetValidLabelValues().end();
+	 ++vIt){
+	if ( markstats->HasLabel(*vIt) ){
+	    typename OutputImType::PixelType labelValue = *vIt;
+	    if ( markstats->GetCount(labelValue) > msize){
+		msize = markstats->GetCount(labelValue);
+		MMean = markstats->GetMean(labelValue);
+		MSigma = markstats->GetSigma(labelValue);
+		}
+	    }
+	}
+
+    std::cout << "Stats " << msize << " " << MMean << " " << MSigma << std::endl;
+
+    // create a mask to remove bright border pixels
+    typedef typename itk::Image<unsigned char, InImType::ImageDimension > MaskImType;
+    typedef typename itk::BinaryThresholdImageFilter<InImType, MaskImType> ThreshType;
+    typename ThreshType::Pointer thresh = ThreshType::New();
+    thresh->SetInput(input);
+    thresh->SetUpperThreshold(MMean - MSigma);
+    thresh->SetInsideValue(1);
+    thresh->SetOutsideValue(0);
+
+    typedef typename itk::MaskImageFilter<OutputImType, MaskImType, OutputImType> MaskerType;
+    typename MaskerType::Pointer masker = MaskerType::New();
+    masker->SetInput(select->GetOutput());
+    masker->SetInput2(thresh->GetOutput());
+
+    typename OutputImType::Pointer result = masker->GetOutput();
+    result->Update();
+    result->DisconnectPipeline();
+    return(result);
+    }
 
 template <class InImType> 
-typename InImType::Pointer computeGrad(typename InImType::Pointer input,
-					   int radius,
-					   float smooth)
-{
-  // Compute a smoothed morphological gradient - original - erosion
-  // optionally smooth it. This gradient will put the peaks on the
-  // outside of a thin dark line, which I think is desirable for this
-  // application.
-  typedef typename itk::FlatStructuringElement< InImType::ImageDimension > SRType;
-  typename SRType::RadiusType rad;
-  rad.Fill(radius);
-  SRType kernel;
+typename InImType::Pointer computeGrad(
+    typename InImType::Pointer input,
+    int radius,
+    float smooth){
+    // Compute a smoothed morphological gradient - original - erosion
+    // optionally smooth it. This gradient will put the peaks on the
+    // outside of a thin dark line, which I think is desirable for this
+    // application.
+    typedef typename itk::FlatStructuringElement< InImType::ImageDimension > SRType;
+    typename SRType::RadiusType rad;
+    rad.Fill(radius);
+    SRType kernel;
 
-  kernel = SRType::Box(rad);
+    kernel = SRType::Box(rad);
 
-  typedef typename itk::GrayscaleErodeImageFilter<InImType, InImType, SRType> ErodeType;
-  typename ErodeType::Pointer erode = ErodeType::New();
-  erode->SetInput(input);
-  erode->SetKernel(kernel);
+    typedef typename itk::GrayscaleErodeImageFilter<InImType, InImType, SRType> ErodeType;
+    typename ErodeType::Pointer erode = ErodeType::New();
+    erode->SetInput(input);
+    erode->SetKernel(kernel);
 
-  typedef typename itk::SubtractImageFilter<InImType, InImType, InImType> SubType;
-  typename SubType::Pointer sub = SubType::New();
-  sub->SetInput(input);
-  sub->SetInput2(erode->GetOutput());
-  typename InImType::Pointer result = sub->GetOutput();
-  typedef typename itk::SmoothingRecursiveGaussianImageFilter<InImType, InImType> SmoothType;
-  typename SmoothType::Pointer smoother = SmoothType::New();
+    typedef typename itk::SubtractImageFilter<InImType, InImType, InImType> SubType;
+    typename SubType::Pointer sub = SubType::New();
+    sub->SetInput(input);
+    sub->SetInput2(erode->GetOutput());
+    typename InImType::Pointer result = sub->GetOutput();
+    typedef typename itk::SmoothingRecursiveGaussianImageFilter<InImType, InImType> SmoothType;
+    typename SmoothType::Pointer smoother = SmoothType::New();
   
-  typename InImType::SpacingType sp = input->GetSpacing();
+    typename InImType::SpacingType sp = input->GetSpacing();
 
-  if (smooth > 0)
-    {
-    // Lazy - assume isotropic
-    float sigma = sp[0] * smooth;
-    smoother->SetInput(sub->GetOutput());
-    smoother->SetSigma(sigma);
-    result = smoother->GetOutput();
+    if (smooth > 0){
+	// Lazy - assume isotropic
+	float sigma = sp[0] * smooth;
+	smoother->SetInput(sub->GetOutput());
+	smoother->SetSigma(sigma);
+	result = smoother->GetOutput();
+	}
+
+    result->Update();
+    result->DisconnectPipeline();
+    return(result);
     }
-
-  result->Update();
-  result->DisconnectPipeline();
-  return(result);
-}
 #define USE_FLOAT
 #define USE_UI32
 template<typename InputComponentType, typename InputPixelType, size_t Dimension>

--- a/segmentLung.cxx
+++ b/segmentLung.cxx
@@ -1,0 +1,290 @@
+/////program to watershed an image
+//01: based on template.cxx and old watershed_morph.cxx
+
+////ToDo:
+// - set OutputPixelType depending on amount of found WS
+// -- or issue warning if amount of found WS do not fit into pixel value range
+
+
+#include "itkFilterWatcher.h"
+#include <itkImageFileReader.h>
+#include <itkShiftScaleImageFilter.h>
+#include <itkMorphologicalWatershedImageFilter.h>
+#include <itkImageFileWriter.h>
+
+
+
+template<typename InputComponentType, typename InputPixelType, size_t Dimension>
+int DoIt(int argc, char *argv[]){
+
+#ifdef USE_FLOAT
+    typedef float  TRealType;
+    std::cerr << "Using single precision (float)." << std::endl;
+#else
+    typedef double TRealType;
+    std::cerr << "Using double precision (double)." << std::endl;
+#endif
+
+#ifdef USE_UI32
+    typedef uint32_t  OutputPixelType;
+    std::cerr << "Using uInt32." << std::endl;
+#else
+    typedef uint64_t  OutputPixelType;
+    std::cerr << "Using uInt64." << std::endl;
+#endif
+
+    typedef itk::Image<InputPixelType, Dimension>  InputImageType;
+    typedef itk::Image<TRealType, Dimension>        GreyImageType;
+    typedef itk::Image<OutputPixelType, Dimension>  OutputImageType;
+
+
+    typedef itk::ImageFileReader<InputImageType> ReaderType;
+    typename ReaderType::Pointer reader = ReaderType::New();
+
+    reader->SetFileName(argv[1]);
+    reader->ReleaseDataFlagOn();
+    FilterWatcher watcherI(reader);
+    watcherI.QuietOn();
+    watcherI.ReportTimeOn();
+    try{
+        reader->Update();
+        }
+    catch(itk::ExceptionObject &ex){
+        std::cerr << ex << std::endl;
+        return EXIT_FAILURE;
+        }
+
+
+    typename OutputImageType::Pointer output;
+
+    if(atoi(argv[7])){ // GreyImageType for inversion, slower WS?
+	typedef itk::ShiftScaleImageFilter<InputImageType, GreyImageType> SSType;
+	typename SSType::Pointer ss = SSType::New();
+	ss->SetScale(-1); //invert by mul. with -1
+	ss->SetInput(reader->GetOutput());
+	ss->ReleaseDataFlagOn();
+	FilterWatcher watcherS(ss);
+
+	typedef itk::MorphologicalWatershedImageFilter<GreyImageType, OutputImageType> FilterType;
+	typename FilterType::Pointer filter= FilterType::New();
+	filter->SetInput(ss->GetOutput());
+	filter->ReleaseDataFlagOn();
+	filter->SetLevel(atoi(argv[4]));
+	filter->SetFullyConnected(atoi(argv[5]));
+	filter->SetMarkWatershedLine(atoi(argv[6]));
+
+	FilterWatcher watcher1(filter);
+	try{
+	    filter->Update();
+	    }
+	catch(itk::ExceptionObject &ex){
+	    std::cerr << ex << std::endl;
+	    return EXIT_FAILURE;
+	    }
+	
+	output= filter->GetOutput();
+	}
+    else{ // avoid GreyImageType if not necessary, faster WS?
+	typedef itk::MorphologicalWatershedImageFilter<InputImageType, OutputImageType> FilterType;
+	typename FilterType::Pointer filter= FilterType::New();
+	filter->SetInput(reader->GetOutput());
+	filter->ReleaseDataFlagOn();
+	filter->SetLevel(atoi(argv[4]));
+	filter->SetFullyConnected(atoi(argv[5]));
+	filter->SetMarkWatershedLine(atoi(argv[6]));
+
+	FilterWatcher watcher1(filter);
+	try{
+	    filter->Update();
+	    }
+	catch(itk::ExceptionObject &ex){
+	    std::cerr << ex << std::endl;
+	    return EXIT_FAILURE;
+	    }
+
+	output= filter->GetOutput();
+	}
+
+
+    typedef itk::ImageFileWriter<OutputImageType>  WriterType;
+    typename WriterType::Pointer writer = WriterType::New();
+
+    FilterWatcher watcherO(writer);
+    writer->SetFileName(argv[2]);
+    writer->SetInput(output);
+    writer->SetUseCompression(atoi(argv[3]));
+    try{
+        writer->Update();
+        }
+    catch(itk::ExceptionObject &ex){
+        std::cerr << ex << std::endl;
+        return EXIT_FAILURE;
+        }
+
+    return EXIT_SUCCESS;
+
+    }
+
+
+template<typename InputComponentType, typename InputPixelType>
+int dispatch_D(size_t dimensionType, int argc, char *argv[]){
+    int res= 0;
+    switch (dimensionType){
+    // case 1:
+    //     res= DoIt<InputComponentType, InputPixelType, 1>(argc, argv);
+    //     break;
+    case 2:
+        res= DoIt<InputComponentType, InputPixelType, 2>(argc, argv);
+        break;
+    case 3:
+        res= DoIt<InputComponentType, InputPixelType, 3>(argc, argv);
+        break;
+    default:
+        std::cerr << "Error: Images of dimension " << dimensionType << " are not handled!" << std::endl;
+        break;
+        }//switch
+    return res;
+    }
+
+template<typename InputComponentType>
+int dispatch_pT(itk::ImageIOBase::IOPixelType pixelType, size_t dimensionType, int argc, char *argv[]){
+    int res= 0;
+    //http://www.itk.org/Doxygen45/html/classitk_1_1ImageIOBase.html#abd189f096c2a1b3ea559bc3e4849f658
+    //http://www.itk.org/Doxygen45/html/itkImageIOBase_8h_source.html#l00099
+    //IOPixelType:: UNKNOWNPIXELTYPE, SCALAR, RGB, RGBA, OFFSET, VECTOR, POINT, COVARIANTVECTOR, SYMMETRICSECONDRANKTENSOR, DIFFUSIONTENSOR3D, COMPLEX, FIXEDARRAY, MATRIX
+
+    switch (pixelType){
+    case itk::ImageIOBase::SCALAR:{
+        typedef InputComponentType InputPixelType;
+        res= dispatch_D<InputComponentType, InputPixelType>(dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::UNKNOWNPIXELTYPE:
+    default:
+        std::cerr << std::endl << "Error: Pixel type not handled!" << std::endl;
+        break;
+        }//switch
+    return res;
+    }
+
+int dispatch_cT(itk::ImageIOBase::IOComponentType componentType, itk::ImageIOBase::IOPixelType pixelType, size_t dimensionType, int argc, char *argv[]){
+    int res= 0;
+
+    //http://www.itk.org/Doxygen45/html/classitk_1_1ImageIOBase.html#a8dc783055a0af6f0a5a26cb080feb178
+    //http://www.itk.org/Doxygen45/html/itkImageIOBase_8h_source.html#l00107
+    //IOComponentType: UNKNOWNCOMPONENTTYPE, UCHAR, CHAR, USHORT, SHORT, UINT, INT, ULONG, LONG, FLOAT, DOUBLE
+
+    switch (componentType){
+    case itk::ImageIOBase::UCHAR:{        // uint8_t
+        typedef unsigned char InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::CHAR:{         // int8_t
+        typedef char InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::USHORT:{       // uint16_t
+        typedef unsigned short InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::SHORT:{        // int16_t
+        typedef short InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::UINT:{         // uint32_t
+        typedef unsigned int InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::INT:{          // int32_t
+        typedef int InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::ULONG:{        // uint64_t
+        typedef unsigned long InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::LONG:{         // int64_t
+        typedef long InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::FLOAT:{        // float32
+        typedef float InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::DOUBLE:{       // float64
+        typedef double InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+    default:
+        std::cerr << "unknown component type" << std::endl;
+        break;
+        }//switch
+    return res;
+    }
+
+
+////from http://itk-users.7.n7.nabble.com/Pad-image-with-0-but-keep-its-type-what-ever-it-is-td27442.html
+//namespace itk{
+  // Description:
+  // Get the PixelType and ComponentType from fileName
+
+void GetImageType (std::string fileName,
+    itk::ImageIOBase::IOPixelType &pixelType,
+    itk::ImageIOBase::IOComponentType &componentType,
+    size_t &dimensionType
+    ){
+    typedef itk::Image<char, 1> ImageType; //template initialization parameters need to be given but can be arbitrary here
+    itk::ImageFileReader<ImageType>::Pointer imageReader= itk::ImageFileReader<ImageType>::New();
+    imageReader->SetFileName(fileName.c_str());
+    imageReader->UpdateOutputInformation();
+
+    pixelType = imageReader->GetImageIO()->GetPixelType();
+    componentType = imageReader->GetImageIO()->GetComponentType();
+    dimensionType= imageReader->GetImageIO()->GetNumberOfDimensions();
+
+    std::cerr << std::endl << "dimensions: " << dimensionType << std::endl;
+    std::cerr << "component type: " << imageReader->GetImageIO()->GetComponentTypeAsString(componentType) << std::endl;
+    std::cerr << "component size: " << imageReader->GetImageIO()->GetComponentSize() << std::endl;
+    std::cerr << "pixel type (string): " << imageReader->GetImageIO()->GetPixelTypeAsString(imageReader->GetImageIO()->GetPixelType()) << std::endl;
+    std::cerr << "pixel type: " << pixelType << std::endl << std::endl;
+
+    }
+
+
+
+int main(int argc, char *argv[]){
+    if ( argc != 8 ){
+        std::cerr << "Missing Parameters: "
+                  << argv[0]
+                  << " Input_Image"
+                  << " Output_Image"
+                  << " compress"
+                  << " level connectivity lines"
+                  << " invert"
+                  << std::endl;
+
+        return EXIT_FAILURE;
+        }
+
+    itk::ImageIOBase::IOPixelType pixelType;
+    typename itk::ImageIOBase::IOComponentType componentType;
+    size_t dimensionType;
+
+
+    try {
+        GetImageType(argv[1], pixelType, componentType, dimensionType);
+        }//try
+    catch( itk::ExceptionObject &excep){
+        std::cerr << argv[0] << ": exception caught !" << std::endl;
+        std::cerr << excep << std::endl;
+        return EXIT_FAILURE;
+        }
+
+    return dispatch_cT(componentType, pixelType, dimensionType, argc, argv);
+    }
+
+
+
+
+
+


### PR DESCRIPTION
## About the pull request

You may not want to incorporate this straight away. I've included a command line processing library that I always use - tclap - as a git submodule. I've found it useful and simpler when dealing with potentially complex command lines. You may not want it.

## The idea

This is a first pass at what I was suggesting. The general idea is pretty simple:

1. Create markers for bright regions - Otsu threshold, followed by moderate erosion, then keep components of minimum size. Both erosion and component size are user options.

1. Apply watershed using those markers and the inverse of the image as a control. The idea is to collect watershed boundaries, which will be in dark regions, as an additional marker in the next phase. The potential issue is that sometimes bright regions can be broken into two, and thus will have a boundary between them on bright areas. I've attempted to remove these parts using thresholding, but it may not work well enough to be compatible with the click'n join cleanup. Suggestions on this later.

1. Combine the watershed boundaries and the original markers, create a control image using a smoothed morphological gradient, then apply a second stage watershed. We can separate bright and dark regions based on the way we constructed the markers. Since I think the bright regions are of interest, I've discarded the dark regions (i.e. those create from the marker derived from the stage 1 watershed).

I've run my tests as follows:

```bash
 ./Build/segmentLung -i ${HOME}/ol87_scratch/RomanGrothausmann/s02_bi3_rs+1+150_smROI_ROI001.mha -o  ${HOME}/ol87_scratch/RomanGrothausmann/tess.mha --markervol 100000 --markererode 15 --debugfolder ${HOME}/ol87_scratch/RomanGrothausmann/ -d --gradsigma 0.5
```
This takes lots of RAM (I haven't done any optimization, and test host has 160GB), and takes about

## Anticipated problems

I've noticed some sort of particle in some of the bright regions in the test image. They often end up as part of the "background" as they are touching one another and the edge of the bright region containing them. If they were isolated from one another or the other background they'd get assigned to the region class. I'm not sure what the desired outcome is. If the preference is to separate them in some way, I'd suggest editing the markers from this procedure. An obvious option would be to extend the region marker into the particles by hand. I'd run the entire procedure, then view the results as well as the phase 2 marker image (and possibly the phase 1 as well). If you identify problem regions then you can modify the markers, either by a quick manual scribble or by joining some separate ones, the rerun the required steps using subsets of the code I've sent or something in your existing library. The first watershed is taking about 20minutes on my test host, and the second one (without separate boundaries) is a bit quicker, so you should see an improvement over previous approach.

Anyhow, hopefully this helps.

