### PR TITLE
Tophat speed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,7 @@ tophat-speed:
   variables:
     CMD:    " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output.mha      0  0.005 -1 && stat output.mha      2>/dev/null "
     CMDSDI: " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output_SDI.mha 10  0.005 -1 && stat output_SDI.mha  2>/dev/null "
-    MD5: 9f0b98715bb318f1be38bfdcea625184
+    MD5: 7dd303d1990c9808d605d17353b8ea8b
 
 min-path_seg_f32.0: # 0: IterateNeighborhoodOptimizer
   <<: *test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,7 @@ tophat-speed:
   variables:
     CMD:    " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output.mha      0  0.005 -1 && stat output.mha      2>/dev/null "
     CMDSDI: " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output_SDI.mha 10  0.005 -1 && stat output_SDI.mha  2>/dev/null "
-    MD5: 7dd303d1990c9808d605d17353b8ea8b
+    MD5: b60d10e8eec163933792969d9f20e0a3
 
 min-path_seg_f32.0: # 0: IterateNeighborhoodOptimizer
   <<: *test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,6 +147,13 @@ tophat:
     CMDSDI: " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output_SDI.mha 10  1 1 && stat output_SDI.mha  2>/dev/null "
     MD5: 6a7594203d2065331368b702abd9aac8
 
+tophat-speed:
+  <<: *testSDI
+  variables:
+    CMD:    " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output.mha      0  0.005 -1 && stat output.mha      2>/dev/null "
+    CMDSDI: " /usr/bin/time -v $CI_JOB_NAME       tests/data/ACN_speed.mhd output_SDI.mha 10  0.005 -1 && stat output_SDI.mha  2>/dev/null "
+    MD5: 9f0b98715bb318f1be38bfdcea625184
+
 min-path_seg_f32.0: # 0: IterateNeighborhoodOptimizer
   <<: *test
   variables: # YAML interprets \r and \n in double quotes! https://stackoverflow.com/questions/24291402/how-to-store-or-read-a-literal-carriage-return-and-newline-from-yaml-in-python#24291536

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,3 +691,8 @@ SET(CurrentExe "tophat")
 ADD_EXECUTABLE(${CurrentExe}  ${CurrentExe})
 TARGET_LINK_LIBRARIES(${CurrentExe}  ${Libraries})
 INSTALL(TARGETS  ${CurrentExe}  RUNTIME  DESTINATION  bin)
+
+SET(CurrentExe "tophat-speed")
+ADD_EXECUTABLE(${CurrentExe}  ${CurrentExe})
+TARGET_LINK_LIBRARIES(${CurrentExe}  ${Libraries})
+INSTALL(TARGETS  ${CurrentExe}  RUNTIME  DESTINATION  bin)

--- a/tophat-speed.cxx
+++ b/tophat-speed.cxx
@@ -34,7 +34,7 @@ int DoIt(int argc, char *argv[]){
 
     reader->SetFileName(argv[1]);
     // reader->ReleaseDataFlagOn(); // needed by filter and th
-    FilterWatcher watcherI(reader);
+    if(noSDI) FilterWatcher watcherI(reader);
     reader->UpdateOutputInformation();
 	
     const typename InputImageType::Pointer& input= reader->GetOutput();
@@ -53,7 +53,7 @@ int DoIt(int argc, char *argv[]){
     filter->SetInput(input);
     filter->SetKernel(structuringElement);
     // filter->ReleaseDataFlagOn(); // needed by stat and add
-    FilterWatcher watcher1(filter);
+    if(noSDI) FilterWatcher watcher1(filter);
 
     const typename OutputImageType::Pointer& wth= filter->GetOutput();
 
@@ -75,7 +75,7 @@ int DoIt(int argc, char *argv[]){
     th->SetOutsideValue(0);
     th->SetInsideValue(bgconst);
     // th->ReleaseDataFlagOn();
-    FilterWatcher watcherT(th);
+    if(noSDI) FilterWatcher watcherT(th);
 
     typedef itk::AddImageFilter<InputImageType, InputImageType, InputImageType> AddType;
     typename AddType::Pointer add = AddType::New();
@@ -83,7 +83,7 @@ int DoIt(int argc, char *argv[]){
     add->SetInput2(th->GetOutput());
     add->ReleaseDataFlagOn();
     add->InPlaceOn(); // overwrites input1
-    FilterWatcher watcherA(add);
+    if(noSDI) FilterWatcher watcherA(add);
 
     typedef itk::DiscreteGaussianImageFilter<InputImageType, InputImageType> SmoothType;
     typename SmoothType::Pointer smooth= SmoothType::New();
@@ -91,7 +91,7 @@ int DoIt(int argc, char *argv[]){
     smooth->SetVariance(std::pow(input->GetSpacing().GetVnlVector().min_value(), 2)); // sigma == stdDev, sigma^2 == variance https://en.wikipedia.org/wiki/Normal_distribution ;  std::min(input->GetSpacing()) not working due to incompatible types  https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
     smooth->SetUseImageSpacingOn(); // default: On
     // smooth->ReleaseDataFlagOn();
-    FilterWatcher watcherSM(smooth);
+    if(noSDI) FilterWatcher watcherSM(smooth);
 
     typedef itk::MaskImageFilter<InputImageType, InputImageType, InputImageType> MaskType;
     typename MaskType::Pointer mask = MaskType::New();
@@ -99,7 +99,7 @@ int DoIt(int argc, char *argv[]){
     mask->SetMaskImage(th->GetOutput()); // needs re-exec th->Update() if th->ReleaseDataFlagOn()
     // mask->ReleaseDataFlagOn(); // needed by stat and mult
     mask->InPlaceOn(); // overwrites SetInput
-    FilterWatcher watcherM(mask);
+    if(noSDI) FilterWatcher watcherM(mask);
 
     stat->SetInput(mask->GetOutput());
     stat->Update();
@@ -108,7 +108,7 @@ int DoIt(int argc, char *argv[]){
     typename MultType::Pointer mult = MultType::New();
     mult->SetInput(mask->GetOutput());
     mult->SetConstant(1.0 / stat->GetMaximum());
-    FilterWatcher watcherMU(mult);
+    if(noSDI) FilterWatcher watcherMU(mult);
 
     const typename OutputImageType::Pointer& output= mult->GetOutput();
 

--- a/tophat-speed.cxx
+++ b/tophat-speed.cxx
@@ -11,7 +11,7 @@
 #include <itkStatisticsImageFilter.h>
 #include <itkBinaryThresholdImageFilter.h>
 #include <itkAddImageFilter.h>
-#include <itkSmoothingRecursiveGaussianImageFilter.h>
+#include <itkDiscreteGaussianImageFilter.h>
 #include <itkMaskImageFilter.h>
 #include <itkMultiplyImageFilter.h>
 #include <itkImageFileWriter.h>
@@ -85,13 +85,12 @@ int DoIt(int argc, char *argv[]){
     add->InPlaceOn(); // overwrites input1
     FilterWatcher watcherA(add);
 
-    typedef itk::SmoothingRecursiveGaussianImageFilter<InputImageType, InputImageType> SmoothType;
+    typedef itk::DiscreteGaussianImageFilter<InputImageType, InputImageType> SmoothType;
     typename SmoothType::Pointer smooth= SmoothType::New();
     smooth->SetInput(add->GetOutput());
-    smooth->SetSigma(input->GetSpacing().GetVnlVector().min_value()); // std::min(input->GetSpacing()) not working due to incompatible types  https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
-    smooth->NormalizeAcrossScaleOff();
-    smooth->ReleaseDataFlagOn();
-    smooth->InPlaceOn();
+    smooth->SetVariance(std::pow(input->GetSpacing().GetVnlVector().min_value(), 2)); // sigma == stdDev, sigma^2 == variance https://en.wikipedia.org/wiki/Normal_distribution ;  std::min(input->GetSpacing()) not working due to incompatible types  https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_vector.h
+    smooth->SetUseImageSpacingOn(); // default: On
+    // smooth->ReleaseDataFlagOn();
     FilterWatcher watcherSM(smooth);
 
     typedef itk::MaskImageFilter<InputImageType, InputImageType, InputImageType> MaskType;

--- a/tophat-speed.cxx
+++ b/tophat-speed.cxx
@@ -33,7 +33,7 @@ int DoIt(int argc, char *argv[]){
     typename ReaderType::Pointer reader = ReaderType::New();
 
     reader->SetFileName(argv[1]);
-    reader->ReleaseDataFlagOn();
+    // reader->ReleaseDataFlagOn(); // needed by filter and th
     if(noSDI){
 	FilterWatcher watcherI(reader);
 	watcherI.QuietOn();
@@ -65,7 +65,7 @@ int DoIt(int argc, char *argv[]){
     typename FilterType::Pointer filter= FilterType::New();
     filter->SetInput(input);
     filter->SetKernel(structuringElement);
-    filter->ReleaseDataFlagOn();
+    // filter->ReleaseDataFlagOn(); // needed by stat and add
 
     if(noSDI){
 	FilterWatcher watcher1(filter);
@@ -93,7 +93,7 @@ int DoIt(int argc, char *argv[]){
     
     typedef itk::BinaryThresholdImageFilter<InputImageType, InputImageType> ThreshType;
     typename ThreshType::Pointer th= ThreshType::New();
-    th->SetInput(input);
+    th->SetInput(input); // needs re-exec reader->Update() if reader->ReleaseDataFlagOn() https://insightsoftwareconsortium.atlassian.net/browse/ITK-3351?attachmentOrder=desc
     th->SetUpperThreshold(0);
     th->SetOutsideValue(0);
     th->SetInsideValue(bgconst);
@@ -102,7 +102,7 @@ int DoIt(int argc, char *argv[]){
 
     typedef itk::AddImageFilter<InputImageType, InputImageType, InputImageType> AddType;
     typename AddType::Pointer add = AddType::New();
-    add->SetInput1(wth);
+    add->SetInput1(wth); // needs re-exec filter->Update() if filter->ReleaseDataFlagOn() https://insightsoftwareconsortium.atlassian.net/browse/ITK-3351?attachmentOrder=desc
     add->SetInput2(th->GetOutput());
     add->ReleaseDataFlagOn();
     add->InPlaceOn(); // overwrites input1
@@ -120,8 +120,8 @@ int DoIt(int argc, char *argv[]){
     typedef itk::MaskImageFilter<InputImageType, InputImageType, InputImageType> MaskType;
     typename MaskType::Pointer mask = MaskType::New();
     mask->SetInput(smooth->GetOutput());
-    mask->SetMaskImage(th->GetOutput());
-    mask->ReleaseDataFlagOn();
+    mask->SetMaskImage(th->GetOutput()); // needs re-exec th->Update() if th->ReleaseDataFlagOn()
+    // mask->ReleaseDataFlagOn(); // needed by stat and mult
     mask->InPlaceOn(); // overwrites SetInput
     FilterWatcher watcherM(mask);
 

--- a/tophat-speed.cxx
+++ b/tophat-speed.cxx
@@ -94,7 +94,7 @@ int DoIt(int argc, char *argv[]){
     typedef itk::BinaryThresholdImageFilter<InputImageType, InputImageType> ThreshType;
     typename ThreshType::Pointer th= ThreshType::New();
     th->SetInput(input); // needs re-exec reader->Update() if reader->ReleaseDataFlagOn() https://insightsoftwareconsortium.atlassian.net/browse/ITK-3351?attachmentOrder=desc
-    th->SetUpperThreshold(0);
+    th->SetLowerThreshold(0); // input > 0
     th->SetOutsideValue(0);
     th->SetInsideValue(bgconst);
     // th->ReleaseDataFlagOn();

--- a/tophat-speed.cxx
+++ b/tophat-speed.cxx
@@ -1,0 +1,287 @@
+////program for WhiteTopHatImageFilter
+//01: based on template.cxx
+
+
+#include <complex>
+
+#include "itkFilterWatcher.h"
+#include <itkImageFileReader.h>
+#include <itkBinaryBallStructuringElement.h>
+#include <itkWhiteTopHatImageFilter.h>
+#include <itkImageFileWriter.h>
+
+
+
+template<typename InputComponentType, typename InputPixelType, size_t Dimension>
+int DoIt(int argc, char *argv[]){
+
+    typedef InputPixelType  OutputPixelType;
+
+    typedef itk::Image<InputPixelType, Dimension>  InputImageType;
+    typedef itk::Image<OutputPixelType, Dimension>  OutputImageType;
+
+    int CompChunk= atoi(argv[3]);
+    bool noSDI= CompChunk <= 1; // SDI only if CompChunk > 1
+
+    typedef itk::ImageFileReader<InputImageType> ReaderType;
+    typename ReaderType::Pointer reader = ReaderType::New();
+
+    reader->SetFileName(argv[1]);
+    reader->ReleaseDataFlagOn();
+    if(noSDI){
+	FilterWatcher watcherI(reader);
+	watcherI.QuietOn();
+	watcherI.ReportTimeOn();
+	try{
+	    reader->Update();
+	    }
+	catch(itk::ExceptionObject &ex){
+	    std::cerr << ex << std::endl;
+	    return EXIT_FAILURE;
+	    }
+	}
+    else{
+	reader->UpdateOutputInformation();
+	}
+	
+    const typename InputImageType::Pointer& input= reader->GetOutput();
+
+
+
+    typedef itk::BinaryBallStructuringElement<InputPixelType, Dimension> StructuringElementType;
+    StructuringElementType  structuringElement;
+
+    structuringElement.SetRadius(atoi(argv[4])); // SITK procedural interface uses a default radius of 1: https://itk.org/SimpleITKDoxygen/html/namespaceitk_1_1simple.html#a106c90567c31d49b3d08fff7be93483f
+    structuringElement.CreateStructuringElement();
+
+    typedef itk::WhiteTopHatImageFilter<InputImageType, OutputImageType, StructuringElementType> FilterType;
+    typename FilterType::Pointer filter= FilterType::New();
+    filter->SetInput(input);
+    filter->SetKernel(structuringElement);
+    filter->SetSafeBorder(atoi(argv[5])); // default: true https://github.com/InsightSoftwareConsortium/ITK/blob/32b6db797478db8efc5c7e93dde440bfc07f3307/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx#L33
+    // filter->SetAlgorithm(HISTO); // https://itk.org/Doxygen/html/classitk_1_1WhiteTopHatImageFilter.html#a0c9e9b9fd763bf22c14d7fbefaec670d  default: HISTO (1) https://github.com/InsightSoftwareConsortium/ITK/blob/32b6db797478db8efc5c7e93dde440bfc07f3307/Modules/Filtering/MathematicalMorphology/include/itkWhiteTopHatImageFilter.hxx#L34
+    filter->ReleaseDataFlagOn();
+
+    if(noSDI){
+	FilterWatcher watcher1(filter);
+	try{
+	    filter->Update();
+	    }
+	catch(itk::ExceptionObject &ex){
+	    std::cerr << ex << std::endl;
+	    return EXIT_FAILURE;
+	    }
+	}
+
+
+    const typename OutputImageType::Pointer& output= filter->GetOutput();
+
+    typedef itk::ImageFileWriter<OutputImageType>  WriterType;
+    typename WriterType::Pointer writer = WriterType::New();
+
+    FilterWatcher watcherO(writer);
+    writer->SetFileName(argv[2]);
+    writer->SetInput(output);
+    if(noSDI){
+	writer->SetUseCompression(CompChunk);
+	}
+    else{
+	writer->UseCompressionOff(); // writing compressed is not supported when streaming!
+	writer->SetNumberOfStreamDivisions(CompChunk);
+	}
+    try{
+        writer->Update();
+        }
+    catch(itk::ExceptionObject &ex){
+        std::cerr << ex << std::endl;
+        return EXIT_FAILURE;
+        }
+
+    return EXIT_SUCCESS;
+
+    }
+
+
+template<typename InputComponentType, typename InputPixelType>
+int dispatch_D(size_t dimensionType, int argc, char *argv[]){
+    int res= EXIT_FAILURE;
+    switch (dimensionType){
+    case 1:
+        res= DoIt<InputComponentType, InputPixelType, 1>(argc, argv);
+        break;
+    case 2:
+        res= DoIt<InputComponentType, InputPixelType, 2>(argc, argv);
+        break;
+    case 3:
+        res= DoIt<InputComponentType, InputPixelType, 3>(argc, argv);
+        break;
+    default:
+        std::cerr << "Error: Images of dimension " << dimensionType << " are not handled!" << std::endl;
+        break;
+        }//switch
+    return res;
+    }
+
+template<typename InputComponentType>
+int dispatch_pT(itk::ImageIOBase::IOPixelType pixelType, size_t dimensionType, int argc, char *argv[]){
+    int res= EXIT_FAILURE;
+    //http://www.itk.org/Doxygen45/html/classitk_1_1ImageIOBase.html#abd189f096c2a1b3ea559bc3e4849f658
+    //http://www.itk.org/Doxygen45/html/itkImageIOBase_8h_source.html#l00099
+    //IOPixelType:: UNKNOWNPIXELTYPE, SCALAR, RGB, RGBA, OFFSET, VECTOR, POINT, COVARIANTVECTOR, SYMMETRICSECONDRANKTENSOR, DIFFUSIONTENSOR3D, COMPLEX, FIXEDARRAY, MATRIX
+
+    switch (pixelType){
+    case itk::ImageIOBase::SCALAR:{ // 1 component per pixel
+        typedef InputComponentType InputPixelType;
+        res= dispatch_D<InputComponentType, InputPixelType>(dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::UNKNOWNPIXELTYPE:
+    default:
+        std::cerr << std::endl << "Error: Pixel type not handled!" << std::endl;
+        break;
+        }//switch
+    return res;
+    }
+
+int dispatch_cT(itk::ImageIOBase::IOComponentType componentType, itk::ImageIOBase::IOPixelType pixelType, size_t dimensionType, int argc, char *argv[]){
+    int res= EXIT_FAILURE;
+
+    //http://www.itk.org/Doxygen45/html/classitk_1_1ImageIOBase.html#a8dc783055a0af6f0a5a26cb080feb178
+    //http://www.itk.org/Doxygen45/html/itkImageIOBase_8h_source.html#l00107
+    //IOComponentType: UNKNOWNCOMPONENTTYPE, UCHAR, CHAR, USHORT, SHORT, UINT, INT, ULONG, LONG, FLOAT, DOUBLE
+
+    switch (componentType){
+    case itk::ImageIOBase::UCHAR:{        // uint8_t
+        typedef unsigned char InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::CHAR:{         // int8_t
+        typedef char InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::USHORT:{       // uint16_t
+        typedef unsigned short InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::SHORT:{        // int16_t
+        typedef short InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::UINT:{         // uint32_t
+        typedef unsigned int InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::INT:{          // int32_t
+        typedef int InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::ULONG:{        // uint64_t
+        typedef unsigned long InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::LONG:{         // int64_t
+        typedef long InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::FLOAT:{        // float32
+        typedef float InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::DOUBLE:{       // float64
+        typedef double InputComponentType;
+        res= dispatch_pT<InputComponentType>(pixelType, dimensionType, argc, argv);
+        } break;
+    case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+    default:
+        std::cerr << "unknown component type" << std::endl;
+        break;
+        }//switch
+    return res;
+    }
+
+
+////from http://itk-users.7.n7.nabble.com/Pad-image-with-0-but-keep-its-type-what-ever-it-is-td27442.html
+//namespace itk{
+  // Description:
+  // Get the PixelType and ComponentType from fileName
+
+void GetImageType (std::string fileName,
+    itk::ImageIOBase::IOPixelType &pixelType,
+    itk::ImageIOBase::IOComponentType &componentType,
+    size_t &dimensionType
+    ){
+    typedef itk::Image<char, 1> ImageType; //template initialization parameters need to be given but can be arbitrary here
+    itk::ImageFileReader<ImageType>::Pointer imageReader= itk::ImageFileReader<ImageType>::New();
+    imageReader->SetFileName(fileName.c_str());
+    imageReader->UpdateOutputInformation();
+
+    if(!imageReader->GetImageIO()->CanStreamRead())
+        std::cerr << "Cannot stream the reading of the input. Streaming will be inefficient!" << std::endl;
+
+    pixelType = imageReader->GetImageIO()->GetPixelType();
+    componentType = imageReader->GetImageIO()->GetComponentType();
+    dimensionType= imageReader->GetImageIO()->GetNumberOfDimensions();
+
+    std::cerr << std::endl << "dimensions: " << dimensionType << std::endl;
+    std::cerr << "component type: " << imageReader->GetImageIO()->GetComponentTypeAsString(componentType) << std::endl;
+    std::cerr << "component size: " << imageReader->GetImageIO()->GetComponentSize() << std::endl;
+    std::cerr << "pixel type (string): " << imageReader->GetImageIO()->GetPixelTypeAsString(imageReader->GetImageIO()->GetPixelType()) << std::endl;
+    std::cerr << "pixel type: " << pixelType << std::endl << std::endl;
+
+    }
+
+
+
+int main(int argc, char *argv[]){
+    if ( argc != 6 ){
+        std::cerr << "Missing Parameters: "
+                  << argv[0]
+                  << " Input_Image"
+                  << " Output_Image"
+                  << " compress|stream-chunks"
+                  << " radius"
+                  << " safeBorder"
+                  << std::endl;
+
+        std::cerr << std::endl;
+        std::cerr << " no-compress: 0, compress: 1, stream > 1" << std::endl;
+        return EXIT_FAILURE;
+        }
+
+    int CompChunk= atoi(argv[3]);
+    std::cerr << std::endl;
+    if(CompChunk == 0){
+	std::cerr << "Employing no compression and no streaming." << std::endl;
+	}
+    else if (CompChunk == 1){
+	std::cerr << "Employing compression (streaming not possible then)." << std::endl;
+	}
+    else if (CompChunk > 1){
+	std::cerr << "Employing streaming (compression not possible then)." << std::endl;
+	}
+    else {
+	std::cerr << "compress|stream-chunks must be a positive integer" << std::endl;
+        return EXIT_FAILURE;
+	}
+
+    itk::ImageIOBase::IOPixelType pixelType;
+    typename itk::ImageIOBase::IOComponentType componentType;
+    size_t dimensionType;
+
+
+    try {
+        GetImageType(argv[1], pixelType, componentType, dimensionType);
+        }//try
+    catch( itk::ExceptionObject &excep){
+        std::cerr << argv[0] << ": exception caught !" << std::endl;
+        std::cerr << excep << std::endl;
+        return EXIT_FAILURE;
+        }
+
+    return dispatch_cT(componentType, pixelType, dimensionType, argc, argv);
+    }
+
+
+
+
+
+

--- a/tophat-speed.cxx
+++ b/tophat-speed.cxx
@@ -34,21 +34,8 @@ int DoIt(int argc, char *argv[]){
 
     reader->SetFileName(argv[1]);
     // reader->ReleaseDataFlagOn(); // needed by filter and th
-    if(noSDI){
-	FilterWatcher watcherI(reader);
-	watcherI.QuietOn();
-	watcherI.ReportTimeOn();
-	try{
-	    reader->Update();
-	    }
-	catch(itk::ExceptionObject &ex){
-	    std::cerr << ex << std::endl;
-	    return EXIT_FAILURE;
-	    }
-	}
-    else{
-	reader->UpdateOutputInformation();
-	}
+    FilterWatcher watcherI(reader);
+    reader->UpdateOutputInformation();
 	
     const typename InputImageType::Pointer& input= reader->GetOutput();
 
@@ -66,17 +53,7 @@ int DoIt(int argc, char *argv[]){
     filter->SetInput(input);
     filter->SetKernel(structuringElement);
     // filter->ReleaseDataFlagOn(); // needed by stat and add
-
-    if(noSDI){
-	FilterWatcher watcher1(filter);
-	try{
-	    filter->Update();
-	    }
-	catch(itk::ExceptionObject &ex){
-	    std::cerr << ex << std::endl;
-	    return EXIT_FAILURE;
-	    }
-	}
+    FilterWatcher watcher1(filter);
 
     const typename OutputImageType::Pointer& wth= filter->GetOutput();
 


### PR DESCRIPTION
ITK-CLI to mimic the SITK-CLI [`tophat-speed.r`](https://github.com/romangrothausmann/SITK-CLIs/blob/4fccdf0450a1b6bcc3ca661e9797f95172c03f2f/tophat-speed.r) but to allow streaming due to the high memory needs of the R-version, see https://github.com/romangrothausmann/SITK-CLIs/pull/3.

`WhiteTopHatImageFilter` needs more than 750GB of mem. for a dataset of 3k^3 voxel while with streaming of 100 chunks the max. mem. needed is ~15GB.
Using `DiscreteGaussianImageFilter` (capable of streaming) instead of `SmoothingRecursiveGaussianImageFilter` (cannot stream) leads to some differences though: https://github.com/romangrothausmann/ITK-CLIs/commit/286450806478807d527fdf5d8d286253ee554338